### PR TITLE
Role add/remove, welcome message functionality, configuration file template

### DIFF
--- a/src/pwnbotsecrets.py
+++ b/src/pwnbotsecrets.py
@@ -1,0 +1,8 @@
+# Required to run the bot
+token = ''
+# Optional, but Required for pwnbot update_channel functionality
+bot_channel = 0
+# Optional, but Required for pwnbot add_role / remove_role functionality (used to display/hide old archived channels that require role to see)
+roles = []
+# Optional, but Required to send a welcome message to new users when they join the server and give them an introduction to CTF
+welcomemsg = ''


### PR DESCRIPTION
This proposed PR would resolve Issue #1 by adding bot functionality for commands !roles & !role. !roles displays a list of bot-owner added roles that the user is permitted to add to themselves, for example to see an archived channel that only the role is permitted to view, and so forth. !role role-name actually adds or removes the requested role to the user, if it exists in said bot-owner controlled list of roles from the configuration file, and first checks if the user already has the role, and if they do, removes it, and adds the role to the user other-wise.

It also resolves issue #2 by importing a welcome message from the configuration file, and if this string exists, sets the required intents to DM a new user when they first join the server, then sends them said welcome message string. If this string is not set in the configuration, then this functionality is not activated and the intents are not required to be set. 

Lastly, a change was made to `on_ready()`, if there is no set `BOT_CHANNEL` value, there is no reason to start the loop for `update_channel()` as it requires the `BOT_CHANNEL` variable to be set to properly run that functionality.

Also, documentation was added to the `!help` command for the two new commands `!roles` and `!role` however it may be bad that this is in the help message even if a `role list` is not configured in the `pwnbotsecrets.py` configuration file, as that would need to be set by the bot owner for a user to even use `!role` or `!roles`. This could be misleading for a user, if the configuration has not been set by the owner. 